### PR TITLE
[Fix] Add Schwab OAuth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,24 @@ Set environment variables for tokens and database URL:
 ```bash
 export TOS_TOKEN=token
 export SCHWAB_TOKEN=token
+export SCHWAB_CLIENT_ID=your_client_id
+export SCHWAB_CLIENT_SECRET=your_client_secret
 export ROBINHOOD_TOKEN=token
 export WEBULL_TOKEN=token
 export DB_URL=postgresql+asyncpg://user:pass@localhost/db
+```
+
+### Schwab login
+
+Generate a browser authorization URL and exchange the returned code for a token:
+
+```python
+from src.clients.schwab_api import CharlesSchwabClient
+
+client = CharlesSchwabClient()
+print(client.get_authorization_url("https://example.com/callback", "state123"))
+# After redirect, call:
+# await client.exchange_code(received_code, "https://example.com/callback")
 ```
 
 Run the service:
@@ -31,6 +46,8 @@ python -m src.run_service
 ```bash
 docker build -t ingestion .
 docker run -e TOS_TOKEN=token -e SCHWAB_TOKEN=token \
+  -e SCHWAB_CLIENT_ID=your_client_id \
+  -e SCHWAB_CLIENT_SECRET=your_client_secret \
   -e ROBINHOOD_TOKEN=token -e WEBULL_TOKEN=token \
   -e DB_URL=postgresql+asyncpg://user:pass@host/db ingestion
 ```

--- a/src/clients/schwab_api.py
+++ b/src/clients/schwab_api.py
@@ -10,8 +10,47 @@ logger = logging.getLogger(__name__)
 class CharlesSchwabClient:
     def __init__(self) -> None:
         self.token = os.getenv("SCHWAB_TOKEN", "")
+        self.client_id = os.getenv("SCHWAB_CLIENT_ID", "")
+        self.client_secret = os.getenv("SCHWAB_CLIENT_SECRET", "")
         self.base_url = "https://api.schwab.com"
+        self.authorization_url = "https://api.schwab.com/oauth2/authorize"
+        self.token_url = "https://api.schwab.com/oauth2/token"
         self.session = aiohttp.ClientSession()
+
+    def get_authorization_url(self, redirect_uri: str, state: str) -> str:
+        """Return the OAuth authorization URL for user login."""
+        params = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "scope": "accounts trading",
+        }
+        url = aiohttp.client.URL("/", encoded=True).with_query(params)
+        query_string = url.query_string
+        return f"{self.authorization_url}?{query_string}"
+
+    async def exchange_code(self, code: str, redirect_uri: str) -> bool:
+        """Exchange an authorization code for an access token."""
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+        try:
+            async with self.session.post(
+                self.token_url,
+                data=data,
+            ) as response:
+                response.raise_for_status()
+                payload = await response.json()
+                self.token = payload.get("access_token", "")
+                return bool(self.token)
+        except Exception as error:  # broad exception for example
+            logger.exception("Token exchange failed: %s", error)
+            return False
 
     async def fetch_balance(self) -> Any:
         url = f"{self.base_url}/balance"
@@ -21,7 +60,10 @@ class CharlesSchwabClient:
                 response.raise_for_status()
                 return await response.json()
         except Exception as error:
-            logger.exception("Error fetching Charles Schwab balance: %s", error)
+            logger.exception(
+                "Error fetching Charles Schwab balance: %s",
+                error,
+            )
             return None
 
     async def fetch_trades(self, since_id: str | None = None) -> list[dict]:

--- a/src/db.py
+++ b/src/db.py
@@ -8,7 +8,10 @@ from sqlalchemy.orm import declarative_base, sessionmaker
 
 logger = logging.getLogger(__name__)
 
-DATABASE_URL = os.getenv("DB_URL", "postgresql+asyncpg://user:password@localhost/db")
+DATABASE_URL = os.getenv(
+    "DB_URL",
+    "postgresql+asyncpg://user:password@localhost/db",
+)
 
 Base = declarative_base()
 
@@ -48,7 +51,11 @@ async def insert_account_balance(
     await session.commit()
 
 
-async def insert_trades(session: AsyncSession, broker: str, trades: list[dict]) -> None:
+async def insert_trades(
+    session: AsyncSession,
+    broker: str,
+    trades: list[dict],
+) -> None:
     for trade in trades:
         record = Trade(broker=broker, trade_id=trade["id"], data=trade)
         session.add(record)

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -32,17 +32,31 @@ class Scheduler:
                 try:
                     balance = await client.fetch_balance()
                     if balance is not None:
-                        await insert_account_balance(self.session, name, balance)
+                        await insert_account_balance(
+                            self.session,
+                            name,
+                            balance,
+                        )
                 except Exception as error:
-                    logger.exception("Balance ingestion failed for %s: %s", name, error)
+                    logger.exception(
+                        "Balance ingestion failed for %s: %s",
+                        name,
+                        error,
+                    )
 
                 try:
-                    trades = await client.fetch_trades(self.last_trade_ids[name])
+                    trades = await client.fetch_trades(
+                        self.last_trade_ids[name],
+                    )
                     if trades:
                         await insert_trades(self.session, name, trades)
                         self.last_trade_ids[name] = trades[-1]["id"]
                 except Exception as error:
-                    logger.exception("Trade ingestion failed for %s: %s", name, error)
+                    logger.exception(
+                        "Trade ingestion failed for %s: %s",
+                        name,
+                        error,
+                    )
 
             await asyncio.sleep(5)
 


### PR DESCRIPTION
## Summary
- add OAuth helper methods to CharlesSchwabClient
- update database helpers for lint
- split long lines in scheduler
- document Schwab OAuth environment variables and usage

## Testing Done
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d10e2c6a883238d016aaacdbbbfa6