### PR TITLE
[Fix] Add docs and test for Schwab OAuth URL

### DIFF
--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -1,0 +1,19 @@
+# Component Overview
+
+This document explains the major modules of the ingestion service.
+
+## scheduler.py
+Coordinates polling brokerage APIs for balances and trades and writes
+results to the database.
+
+## db.py
+Defines the SQLAlchemy models and helper functions for inserting account
+balances and trades.
+
+## clients package
+Contains one client per brokerage. Each client exposes asynchronous
+methods `fetch_balance`, `fetch_trades`, and `close`.
+
+## run_service.py
+Bootstrap file that initializes the database engine, creates tables and
+starts the scheduler.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ export SCHWAB_CLIENT_ID=your_client_id
 export SCHWAB_CLIENT_SECRET=your_client_secret
 export ROBINHOOD_TOKEN=token
 export WEBULL_TOKEN=token
-export DB_URL=postgresql+asyncpg://user:pass@localhost/db
+export DB_URL=postgresql+asyncpg://user:password@localhost/db
 ```
 
 ### Schwab login
@@ -49,7 +49,7 @@ docker run -e TOS_TOKEN=token -e SCHWAB_TOKEN=token \
   -e SCHWAB_CLIENT_ID=your_client_id \
   -e SCHWAB_CLIENT_SECRET=your_client_secret \
   -e ROBINHOOD_TOKEN=token -e WEBULL_TOKEN=token \
-  -e DB_URL=postgresql+asyncpg://user:pass@host/db ingestion
+  -e DB_URL=postgresql+asyncpg://user:password@host/db ingestion
 ```
 
 ### Example HTTP call

--- a/tests/test_schwab_client.py
+++ b/tests/test_schwab_client.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import importlib.util
+from unittest.mock import patch
+import os
+
+module_dir = Path(__file__).resolve().parents[1] / "src" / "clients"
+module_path = module_dir / "schwab_api.py"
+spec = importlib.util.spec_from_file_location("schwab_api", module_path)
+schwab_api = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(schwab_api)
+CharlesSchwabClient = schwab_api.CharlesSchwabClient
+
+
+def test_get_authorization_url() -> None:
+    os.environ["SCHWAB_CLIENT_ID"] = "client123"
+    with patch("aiohttp.ClientSession"):
+        client = CharlesSchwabClient()
+        url = client.get_authorization_url(
+            "https://example.com/callback",
+            "state42",
+        )
+    expected = (
+        "https://api.schwab.com/oauth2/authorize?"
+        "response_type=code&client_id=client123&"
+        "redirect_uri=https://example.com/callback&"
+        "state=state42&scope=accounts trading"
+    )
+    assert url == expected


### PR DESCRIPTION
- Added COMPONENTS.md describing each module
- Fixed DB_URL example in README
- Added unit test for Schwab authorization URL

Testing Done:
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d125a759483239d01950c0312a13b